### PR TITLE
Baikonur-specific logging module: add timestamp_required opt to parser

### DIFF
--- a/amazon_kinesis_utils/baikonur_logging.py
+++ b/amazon_kinesis_utils/baikonur_logging.py
@@ -23,22 +23,23 @@ def parse_payload_to_log_dict(
 ):
     logger.debug(f"Parsing normalized payload: {payload}")
 
-    log_type_unknown = f"{log_type_unknown_prefix}/unknown_type"
+    target_dict = log_dict
 
     log_type, log_type_missing = dict_get_default(
-        payload, key=log_type_key, default=log_type_unknown, verbose=True,
+        payload, key=log_type_key, default=None, verbose=True,
     )
 
     if log_type_missing:
         target_dict = failed_dict
+        log_type = f"{log_type_unknown_prefix}/unknown_type"
     else:
-        target_dict = log_dict
         if (log_type_whitelist is not None) and (log_type not in log_type_whitelist):
             return
 
     timestamp, timestamp_missing = dict_get_default(payload, key=log_timestamp_key, default=None,)
 
     if timestamp_missing and timestamp_required:
+        log_type = f"{log_type_unknown_prefix}/{log_type}/no_timestamp"
         target_dict = failed_dict
 
     log_id, _ = dict_get_default(payload, key=log_id_key, default=None,)

--- a/amazon_kinesis_utils/baikonur_logging.py
+++ b/amazon_kinesis_utils/baikonur_logging.py
@@ -19,6 +19,7 @@ def parse_payload_to_log_dict(
     log_type_key,
     log_type_unknown_prefix,
     log_type_whitelist=None,
+    timestamp_required=False,
 ):
     logger.debug(f"Parsing normalized payload: {payload}")
 
@@ -35,7 +36,10 @@ def parse_payload_to_log_dict(
         if (log_type_whitelist is not None) and (log_type not in log_type_whitelist):
             return
 
-    timestamp, _ = dict_get_default(payload, key=log_timestamp_key, default=None,)
+    timestamp, timestamp_missing = dict_get_default(payload, key=log_timestamp_key, default=None,)
+
+    if timestamp_missing and timestamp_required:
+        target_dict = failed_dict
 
     log_id, _ = dict_get_default(payload, key=log_id_key, default=None,)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
 
 setup(
     name="amazon_kinesis_utils",
-    version="0.1.3",
+    version="0.1.4",
     license="MIT",
     author="Tamirlan Torgayev",
     author_email="torgayev@me.com",


### PR DESCRIPTION
Some modules ( https://github.com/baikonur-oss/terraform-aws-lambda-kinesis-to-es and https://github.com/baikonur-oss/terraform-aws-lambda-kinesis-to-s3 ) require timestamp field to be present, but some ( https://github.com/baikonur-oss/terraform-aws-lambda-kinesis-forward ) don't.

This PR adds optional timestamp_required to log parser.