### PR TITLE
Fix JSON check in parser

### DIFF
--- a/amazon_kinesis_utils/kinesis.py
+++ b/amazon_kinesis_utils/kinesis.py
@@ -45,7 +45,7 @@ def normalize_cloudwatch_messages(payload: str) -> List[str]:
     # check if data is JSON and parse
     try:
         payload_json = json.loads(payload)
-        if type(payload) is not dict:
+        if type(payload_json) is not dict:
             logger.error(f"Top-level JSON data is not an object, giving up: {payload}")
             return []
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
 
 setup(
     name="amazon_kinesis_utils",
-    version="0.1.4",
+    version="0.1.5",
     license="MIT",
     author="Tamirlan Torgayev",
     author_email="torgayev@me.com",


### PR DESCRIPTION
Fix JSON check for payloads. Non-JSON payloads fail json.loads and so are returned as they were. 